### PR TITLE
ChangeControl: Optimize creation by not re-reading changes

### DIFF
--- a/gerrit-server/src/main/java/com/google/gerrit/server/change/MergeabilityChecker.java
+++ b/gerrit-server/src/main/java/com/google/gerrit/server/change/MergeabilityChecker.java
@@ -342,7 +342,7 @@ public class MergeabilityChecker implements GitReferenceUpdatedListener {
         m.setForce(force);
 
         ChangeControl control =
-            changeControlFactory.controlFor(change.getId(), context.getCurrentUser());
+            changeControlFactory.controlFor(change, context.getCurrentUser());
         MergeableInfo info = m.apply(
             new RevisionResource(new ChangeResource(control), ps));
         return change.isMergeable() != info.mergeable;

--- a/gerrit-server/src/main/java/com/google/gerrit/server/change/Rebase.java
+++ b/gerrit-server/src/main/java/com/google/gerrit/server/change/Rebase.java
@@ -68,7 +68,8 @@ public class Rebase implements RestModifyView<RevisionResource, Input>,
     }
 
     try {
-      rebaseChange.get().rebase(rsrc.getPatchSet().getId(), rsrc.getUser());
+      rebaseChange.get().rebase(rsrc.getChange(), rsrc.getPatchSet().getId(),
+          rsrc.getUser());
     } catch (InvalidChangeOperationException e) {
       throw new ResourceConflictException(e.getMessage());
     } catch (IOException e) {

--- a/gerrit-server/src/main/java/com/google/gerrit/server/changedetail/RebaseChange.java
+++ b/gerrit-server/src/main/java/com/google/gerrit/server/changedetail/RebaseChange.java
@@ -95,6 +95,7 @@ public class RebaseChange {
    * E-mail notification and triggering of hooks happens for the creation of the
    * new patch set.
    *
+   * @param change the change to perform the rebase for
    * @param patchSetId the id of the patch set
    * @param uploader the user that creates the rebased patch set
    * @throws NoSuchChangeException thrown if the change to which the patch set
@@ -105,18 +106,17 @@ public class RebaseChange {
    * @throws IOException thrown if rebase is not possible or not needed
    * @throws InvalidChangeOperationException thrown if rebase is not allowed
    */
-  public void rebase(final PatchSet.Id patchSetId, final IdentifiedUser uploader)
+  public void rebase(Change change, PatchSet.Id patchSetId, final IdentifiedUser uploader)
       throws NoSuchChangeException, EmailException, OrmException, IOException,
       InvalidChangeOperationException {
     final Change.Id changeId = patchSetId.getParentKey();
     final ChangeControl changeControl =
-        changeControlFactory.validateFor(changeId, uploader);
+        changeControlFactory.validateFor(change, uploader);
     if (!changeControl.canRebase()) {
       throw new InvalidChangeOperationException(
           "Cannot rebase: New patch sets are not allowed to be added to change: "
               + changeId.toString());
     }
-    final Change change = changeControl.getChange();
     Repository git = null;
     RevWalk rw = null;
     ObjectInserter inserter = null;

--- a/gerrit-server/src/main/java/com/google/gerrit/server/project/ChangeControl.java
+++ b/gerrit-server/src/main/java/com/google/gerrit/server/project/ChangeControl.java
@@ -84,32 +84,9 @@ public class ChangeControl {
       }
     }
 
-    public ChangeControl controlFor(Change.Id id, CurrentUser user)
-        throws NoSuchChangeException {
-      final Change change;
-      try {
-        change = db.get().changes().get(id);
-        if (change == null) {
-          throw new NoSuchChangeException(id);
-        }
-      } catch (OrmException e) {
-        throw new NoSuchChangeException(id, e);
-      }
-      return controlFor(change, user);
-    }
-
     public ChangeControl validateFor(Change change, CurrentUser user)
         throws NoSuchChangeException, OrmException {
       ChangeControl c = controlFor(change, user);
-      if (!c.isVisible(db.get())) {
-        throw new NoSuchChangeException(c.getChange().getId());
-      }
-      return c;
-    }
-
-    public ChangeControl validateFor(Change.Id id, CurrentUser user)
-        throws NoSuchChangeException, OrmException {
-      ChangeControl c = controlFor(id, user);
       if (!c.isVisible(db.get())) {
         throw new NoSuchChangeException(c.getChange().getId());
       }


### PR DESCRIPTION
There are two different controlFor() methods that accept change id
and change. It seems that all callers have change instance available
so there is no need to re-read the changes from the database.

This fixes flaky query tests, see this thread for more details [1].

TEST PLAN:

To reproduce you need heavy load on your machine. For example start
LibreOffice's unit tests parallel to Gerrit's query tests:

  $ libreoffice> make check
  $ gerrit> buck test --no-results-cache //gerrit-server:query_tests

Repeat the last command multiple times. Without this change I observed
2-4 failures from 10 runs.

[1] https://groups.google.com/d/topic/repo-discuss/9wGKjTaVG7k

Change-Id: Ia95458e86b214b12186ca60ccad46d586e13a01c
(cherry picked from commit fa5fd568d0b945632e4dd3f4cff84f56d9e4b1f5)
